### PR TITLE
Updated import path for openzeppelin

### DIFF
--- a/chapter-4/greeter/contracts/Greeter.sol
+++ b/chapter-4/greeter/contracts/Greeter.sol
@@ -1,6 +1,6 @@
 pragma solidity >= 0.4.0 < 0.7.0;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract Greeter is Ownable {
   string private _greeting = "Hello, World!";


### PR DESCRIPTION
The newer OpenZeppelin has the Ownable.sol under the /access/ folder. There is no longer an /ownership/ folder where the file was before.