### PR TITLE
Updated import path for OpenZeppelin 

### DIFF
--- a/chapter-4/greeter/contracts/Greeter.sol
+++ b/chapter-4/greeter/contracts/Greeter.sol
@@ -1,6 +1,6 @@
 pragma solidity >= 0.4.0 < 0.7.0;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract Greeter is Ownable {
   string private _greeting = "Hello, World!";

--- a/chapter-5/greeter/contracts/Greeter.sol
+++ b/chapter-5/greeter/contracts/Greeter.sol
@@ -1,6 +1,6 @@
 pragma solidity >= 0.4.0 < 0.7.0;
 
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/access/Ownable.sol";
 
 contract Greeter is Ownable {
   string private _greeting = "Hello, World!";


### PR DESCRIPTION
Chapter 4 and 5's Greeter contracted used an older import path for Ownable.sol. It is currently under the /access/ folder instead of the /ownership/ folder. 